### PR TITLE
Added missing photo library description.

### DIFF
--- a/SBSAnimoji/Supporting files/Info.plist
+++ b/SBSAnimoji/Supporting files/Info.plist
@@ -24,6 +24,8 @@
 	<string>Tracking your face</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Recording your voice</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Saving your video</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
SBSAnimoji was missing photo library description; caused app to crash on saving Animoji videos from the app when running on device.