### PR TITLE
Bump the time limit to 60 seconds

### DIFF
--- a/SBSAnimoji/Pages/Main/SBSPuppetView.m
+++ b/SBSAnimoji/Pages/Main/SBSPuppetView.m
@@ -7,6 +7,9 @@
 //
 
 #import "SBSPuppetView.h"
+#import <objc/runtime.h>
+
+#define MAX_RECORDING_DURATION 60 // Seconds
 
 @implementation SBSPuppetView
 
@@ -19,6 +22,33 @@
 
 - (void)startRecording {
     [super startRecording];
+    
+    int duration = MAX_RECORDING_DURATION * 60;
+    
+    NSMutableData *timesBuffer = [NSMutableData dataWithCapacity: duration * 8];
+    NSMutableData *blendShapeBuffer = [NSMutableData dataWithCapacity: duration * 204];
+    NSMutableData *transformData = [NSMutableData dataWithCapacity: duration * 64];
+    
+    [self setValue:[NSNumber numberWithInt:duration] forKey:@"_recordingCapacity"];
+    [self setValue:timesBuffer forKey:@"_rawTimesData"];
+    [self setValue:blendShapeBuffer forKey:@"_rawBlendShapesData"];
+    [self setValue:transformData forKey:@"_rawTransformsData"];
+    
+    {
+        Ivar ivar = class_getInstanceVariable([AVTPuppetView class], "_rawTimes");
+        ((void (*)(id, Ivar, void *))object_setIvar)(self, ivar, [timesBuffer mutableBytes]);
+    }
+    
+    {
+        Ivar ivar = class_getInstanceVariable([AVTPuppetView class], "_rawBlendShapes");
+        ((void (*)(id, Ivar, void *))object_setIvar)(self, ivar, [blendShapeBuffer mutableBytes]);
+    }
+    
+    {
+        Ivar ivar = class_getInstanceVariable([AVTPuppetView class], "_rawTransforms");
+        ((void (*)(id, Ivar, void *))object_setIvar)(self, ivar, [transformData mutableBytes]);
+    }
+    
     if ([self.sbsDelegate respondsToSelector:@selector(puppetViewDidStartRecording:)]) {
         [self.sbsDelegate puppetViewDidStartRecording:self];
     }


### PR DESCRIPTION
This PR increases the maximum recording duration to 60 seconds. Since AvatarKit keeps all frames in the memory, it's hard to remove the limitation of the duration completely due to memory constrains.